### PR TITLE
Option to set the cookie path, default "/"

### DIFF
--- a/sess_cookie.go
+++ b/sess_cookie.go
@@ -84,7 +84,7 @@ func (st *CookieSessionStore) SessionRelease(w http.ResponseWriter) {
 	}
 	cookie := &http.Cookie{Name: cookiepder.config.CookieName,
 		Value:    url.QueryEscape(str),
-		Path:     "/",
+		Path:     cookiepder.config.CookiePath,
 		HttpOnly: true,
 		Secure:   cookiepder.config.Secure,
 		MaxAge:   cookiepder.config.Maxage}
@@ -97,6 +97,7 @@ type cookieConfig struct {
 	BlockKey     string `json:"blockKey"`
 	SecurityName string `json:"securityName"`
 	CookieName   string `json:"cookieName"`
+	CookiePath   string `json:"cookiePath"`
 	Secure       bool   `json:"secure"`
 	Maxage       int    `json:"maxage"`
 }


### PR DESCRIPTION
Option to set cookiepath to a suburl instead of domain root so the cookie won't be sent to other applications running on the same domain if a suburl is used.
