### PR TITLE
Fix replication error with mysql based session on gc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: go
 
 go:
-  - 1.3
   - 1.4
   - 1.5
+  - 1.6
+  - 1.7
   - tip
 
 script: go test -v -cover -race

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -185,7 +185,7 @@ func (p *MysqlProvider) Count() (total int) {
 
 // GC calls GC to clean expired sessions.
 func (p *MysqlProvider) GC() {
-	if _, err := p.c.Exec("DELETE FROM session WHERE UNIX_TIMESTAMP(NOW()) - expiry > ?", p.expire); err != nil {
+	if _, err := p.c.Exec("DELETE FROM session WHERE  expiry + ? <= UNIX_TIMESTAMP(NOW())", p.expire); err != nil {
 		log.Printf("session/mysql: error garbage collecting: %v", err)
 	}
 }


### PR DESCRIPTION
Hi there,

we're using grafana with mysql backend and a master-master setup and we get replication errors from time to time. There is an error case when side B had a new session record after the GC was triggered on side A, leading to `expiry > UNIX_TIMESTAMP(NOW())` when the statement is executed on side B (since `NOW()` was replaced with the actual timestamp on side A, see http://dev.mysql.com/doc/refman/5.7/en/replication-features-functions.html). As expiry is unsigned, this results in a failed query and broken replication.

The error we got:
```
Last_SQL_Error: Error 'BIGINT UNSIGNED value is out of range in '(unix_timestamp(now()) - `grafana`.`session`.`expiry`)'' on query. Default database: 'grafana'. 
Query: 'DELETE FROM session WHERE UNIX_TIMESTAMP(NOW()) - expiry > 86400'
```

This change fixes the out of range error.
