### PR TITLE
Ensure that the session ids are of the form that we would have produced

### DIFF
--- a/session.go
+++ b/session.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"gopkg.in/macaron.v1"
@@ -252,12 +251,29 @@ func (m *Manager) sessionID() string {
 	return hex.EncodeToString(generateRandomKey(m.opt.IDLength / 2))
 }
 
+// validSessionID tests whether a provided session ID is a valid session ID
+func (m *Manager) validSessionID(sid string) (bool, error) {
+	if len(sid) != m.opt.IDLength {
+		return false, errors.New("invalid 'sid': " + sid)
+	}
+	for _, c := range sid {
+		switch {
+		case '0' <= c && c <= '9':
+		case 'a' <= c && c <= 'f':
+		default:
+			return false, errors.New("invalid 'sid': " + sid)
+		}
+	}
+	return true, nil
+}
+
 // Start starts a session by generating new one
 // or retrieve existence one by reading session ID from HTTP request if it's valid.
 func (m *Manager) Start(ctx *macaron.Context) (RawStore, error) {
 	sid := ctx.GetCookie(m.opt.CookieName)
-	if len(sid) > 0 && m.provider.Exist(sid) {
-		return m.Read(sid)
+	valid, _ := m.validSessionID(sid)
+	if len(sid) > 0 && valid && m.provider.Exist(sid) {
+		return m.provider.Read(sid)
 	}
 
 	sid = m.sessionID()
@@ -284,10 +300,9 @@ func (m *Manager) Start(ctx *macaron.Context) (RawStore, error) {
 
 // Read returns raw session store by session ID.
 func (m *Manager) Read(sid string) (RawStore, error) {
-	// No slashes or dots "./" should ever occur in the sid and to prevent session file forgery bug.
-	// See https://github.com/gogs/gogs/issues/5469
-	if strings.ContainsAny(sid, "./") {
-		return nil, errors.New("invalid 'sid': " + sid)
+	// Ensure we're trying to read a valid session ID
+	if _, err := m.validSessionID(sid); err != nil {
+		return nil, err
 	}
 
 	return m.provider.Read(sid)
@@ -298,6 +313,10 @@ func (m *Manager) Destory(ctx *macaron.Context) error {
 	sid := ctx.GetCookie(m.opt.CookieName)
 	if len(sid) == 0 {
 		return nil
+	}
+
+	if _, err := m.validSessionID(sid); err != nil {
+		return err
 	}
 
 	if err := m.provider.Destory(sid); err != nil {
@@ -318,6 +337,10 @@ func (m *Manager) Destory(ctx *macaron.Context) error {
 func (m *Manager) RegenerateId(ctx *macaron.Context) (sess RawStore, err error) {
 	sid := m.sessionID()
 	oldsid := ctx.GetCookie(m.opt.CookieName)
+	_, err = m.validSessionID(oldsid)
+	if err != nil {
+		return nil, err
+	}
 	sess, err = m.provider.Regenerate(oldsid, sid)
 	if err != nil {
 		return nil, err

--- a/session_test.go
+++ b/session_test.go
@@ -142,7 +142,7 @@ func testProvider(opt Options) {
 		resp := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/", nil)
 		So(err, ShouldBeNil)
-		req.Header.Set("Cookie", "MacaronSession=ad2c7e3cbecfcf486; Path=/;")
+		req.Header.Set("Cookie", "MacaronSession=ad2c7e3cbecfcf48; Path=/;")
 		m.ServeHTTP(resp, req)
 	})
 


### PR DESCRIPTION
Although the previously applied fix does manage to solve the immediate problem in gogs/gogs#5469. It isn't necessarily completely correct. This fix ensures that sids that are passed to the provider are of the form that macaron-session would produce and adds barriers to the other provider methods.