### PR TITLE
Fixed Destory typo

### DIFF
--- a/couchbase/couchbase.go
+++ b/couchbase/couchbase.go
@@ -172,7 +172,7 @@ func (p *CouchbaseProvider) Exist(sid string) bool {
 	}
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *CouchbaseProvider) Destory(sid string) error {
 	p.b = p.getBucket()
 	defer p.b.Close()

--- a/file.go
+++ b/file.go
@@ -170,7 +170,7 @@ func (p *FileProvider) Exist(sid string) bool {
 	return com.IsFile(p.filepath(sid))
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *FileProvider) Destory(sid string) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/ledis/ledis.go
+++ b/ledis/ledis.go
@@ -174,7 +174,7 @@ func (p *LedisProvider) Exist(sid string) bool {
 	return err == nil && count > 0
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *LedisProvider) Destory(sid string) error {
 	_, err := p.c.Del([]byte(sid))
 	return err

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -152,7 +152,7 @@ func (p *MemcacheProvider) Exist(sid string) bool {
 	return err == nil
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *MemcacheProvider) Destory(sid string) error {
 	return p.c.Delete(sid)
 }

--- a/memory.go
+++ b/memory.go
@@ -89,7 +89,7 @@ type MemProvider struct {
 	lock        sync.RWMutex
 	maxLifetime int64
 	data        map[string]*list.Element
-	// A priority list whose lastAccess newer gets higer priority.
+	// A priority list whose lastAccess newer gets higher priority.
 	list *list.List
 }
 
@@ -145,7 +145,7 @@ func (p *MemProvider) Exist(sid string) bool {
 	return ok
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *MemProvider) Destory(sid string) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -154,7 +154,7 @@ func (p *MysqlProvider) Exist(sid string) bool {
 	return err != sql.ErrNoRows
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *MysqlProvider) Destory(sid string) error {
 	_, err := p.c.Exec("DELETE FROM session WHERE `key`=?", sid)
 	return err

--- a/nodb/nodb.go
+++ b/nodb/nodb.go
@@ -154,7 +154,7 @@ func (p *NodbProvider) Exist(sid string) bool {
 	return err == nil && count > 0
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *NodbProvider) Destory(sid string) error {
 	_, err := p.c.Del([]byte(sid))
 	return err

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -155,7 +155,7 @@ func (p *PostgresProvider) Exist(sid string) bool {
 	return err != sql.ErrNoRows
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *PostgresProvider) Destory(sid string) error {
 	_, err := p.c.Exec("DELETE FROM session WHERE key=$1", sid)
 	return err

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -186,7 +186,7 @@ func (p *RedisProvider) Exist(sid string) bool {
 	return err == nil && has
 }
 
-// Destory deletes a session by session ID.
+// Destroy deletes a session by session ID.
 func (p *RedisProvider) Destory(sid string) error {
 	return p.c.Del(p.prefix + sid).Err()
 }

--- a/session.go
+++ b/session.go
@@ -54,7 +54,7 @@ type Store interface {
 	RawStore
 	// Read returns raw session store by session ID.
 	Read(string) (RawStore, error)
-	// Destory deletes a session.
+	// Destroy deletes a session.
 	Destory(*macaron.Context) error
 	// RegenerateId regenerates a session store from old session ID to new one.
 	RegenerateId(*macaron.Context) (RawStore, error)
@@ -209,7 +209,7 @@ type Provider interface {
 	Read(sid string) (RawStore, error)
 	// Exist returns true if session with given ID exists.
 	Exist(sid string) bool
-	// Destory deletes a session by session ID.
+	// Destroy deletes a session by session ID.
 	Destory(sid string) error
 	// Regenerate regenerates a session store from old session ID to new one.
 	Regenerate(oldsid, sid string) (RawStore, error)
@@ -318,7 +318,7 @@ func (m *Manager) Read(sid string) (RawStore, error) {
 	return m.provider.Read(sid)
 }
 
-// Destory deletes a session by given ID.
+// Destroy deletes a session by given ID.
 func (m *Manager) Destory(ctx *macaron.Context) error {
 	sid := ctx.GetCookie(m.opt.CookieName)
 	if len(sid) == 0 {


### PR DESCRIPTION
Careful, this change fixes a simple typo but will break backwards compatibility.
Thoroughly review, please.